### PR TITLE
Fix clobber obtion being unset

### DIFF
--- a/zsh-dircolors-solarized.zsh
+++ b/zsh-dircolors-solarized.zsh
@@ -25,9 +25,7 @@ function setupsolarized ()
     fi
 
     # Save the settings to a file
-    setopt CLOBBER
-    echo $_SOLARIZED_THEME > $_ZSH_DIRCOLORS_SOLARIZED_CONF
-    unsetopt CLOBBER
+    echo $_SOLARIZED_THEME >! $_ZSH_DIRCOLORS_SOLARIZED_CONF
 }
 
 [[ -e $_ZSH_DIRCOLORS_SOLARIZED_CONF ]] && setupsolarized $(cat $_ZSH_DIRCOLORS_SOLARIZED_CONF)


### PR DESCRIPTION
Currently sourcing `zsh-dircolors-solarized.zsh` disable the `clobber` ZSH option because it is set and then unset here:
https://github.com/joel-porquet/zsh-dircolors-solarized/blob/2d41598785ac7035c3f34a6beaba9c0973ab15e7/zsh-dircolors-solarized.zsh#L28-L30

If the user has set the option before, it is then lost.

This little change makes use of the native ZSH `>!` redirection syntax (http://zsh.sourceforge.net/Doc/Release/Redirection.html), and makes no assumption about the `clobber` option, therefore we do not need to change it anymore.