### PR TITLE
Fixed zsh-dircolors-solarized.plugin.zsh to work with MSYS2

### DIFF
--- a/zsh-dircolors-solarized.plugin.zsh
+++ b/zsh-dircolors-solarized.plugin.zsh
@@ -1,1 +1,1 @@
-zsh-dircolors-solarized.zsh
+source ${0:A:h}/zsh-dircolors-solarized.zsh


### PR DESCRIPTION
I tried to use zsh-dircolors-solarized on MSYS2 and oh-my-zsh. I saw other repos with this pattern and I think zsh-dircolors-solarized should adopt it as well.