### PR TITLE
fix oh-my-zsh instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ also compatible with other plugin managers.
 1. Clone this repository into `$ZSH_CUSTOM/plugins` (by default `~/.oh-my-zsh/custom/plugins`)
 
     ```sh
-    git clone --recursive git://github.com/joel-porquet/zsh-dircolors-solarized $ZSH_CUSTOM/plugins/zsh-dircolors-solarized
+    git clone --recursive https://github.com/joel-porquet/zsh-dircolors-solarized $ZSH_CUSTOM/plugins/zsh-dircolors-solarized
     ```
 
 2. Add the plugin to the list of plugins for Oh My Zsh to load:


### PR DESCRIPTION
The git clone works for me only after I change `git:` to `https:`.